### PR TITLE
Allow for multiple ALLOW_NETWORKS and DENY_NETWORKS

### DIFF
--- a/warden/root/linux/net.sh
+++ b/warden/root/linux/net.sh
@@ -73,7 +73,7 @@ function setup_filter() {
   iptables -N ${filter_default_chain} 2> /dev/null || iptables -F ${filter_default_chain}
 
   # Whitelist
-  for n in "${ALLOW_NETWORKS}"; do
+  for n in ${ALLOW_NETWORKS}; do
     if [ "$n" == "" ]
     then
       break
@@ -82,7 +82,7 @@ function setup_filter() {
     iptables -A ${filter_default_chain} --destination "$n" --jump RETURN
   done
 
-  for n in "${DENY_NETWORKS}"; do
+  for n in ${DENY_NETWORKS}; do
     if [ "$n" == "" ]
     then
       break


### PR DESCRIPTION
Currently the for loop for looping over ALLOW_NETWORKS and DENY_NETWORKS has double quotes around it. This means that all the networks will be treated as a single value and each loop will only happen once (assuming a value has been specified.) The double quotes need to be removed so that multiple networks can be configured.
