### PR TITLE
Inherit nameserver(s) unless is localhost, in which case use

### DIFF
--- a/warden/root/linux/skeleton/setup.sh
+++ b/warden/root/linux/skeleton/setup.sh
@@ -81,8 +81,20 @@ cat > mnt/etc/hosts <<-EOS
 $network_container_ip $id
 EOS
 
-# Inherit nameserver(s)
-cp /etc/resolv.conf mnt/etc/
+# By default, inherit the nameserver from the host container.
+#
+# Exception: When the host's nameserver is set to localhost (127.0.0.1), it is
+# assumed to be running its own DNS server and listening on all interfaces.
+# In this case, the warden container must use the network_host_ip address
+# as the nameserver.
+if [[ "$(cat /etc/resolv.conf)" == "nameserver 127.0.0.1" ]]
+then
+  cat > mnt/etc/resolv.conf <<-EOS
+nameserver $network_host_ip
+EOS
+else
+  cp /etc/resolv.conf mnt/etc/
+fi
 
 # Add vcap user if not already present
 $(which chroot) mnt env -i /bin/bash <<-EOS


### PR DESCRIPTION
This fixes an issue on MCF where warden containers were unable to resolve any DNS because nameserver was set to localhost.
