### PR TITLE
Correct the command for launching the REPL

### DIFF
--- a/warden/README.md
+++ b/warden/README.md
@@ -60,7 +60,7 @@ sudo bundle exec rake warden:start[config/linux.yml]
 #### Interact with Warden
 
 ```
-bundle exec bin/warden-repl
+bundle exec bin/warden repl
 ```
 
 ## Implementation for Linux


### PR DESCRIPTION
There's a minor inaccuracy in the README for the command to launch the REPL. This pull request corrects it.
