### PR TITLE
Remove formatted string - not necessary.

### DIFF
--- a/warden/lib/warden/container/linux.rb
+++ b/warden/lib/warden/container/linux.rb
@@ -222,7 +222,7 @@ module Warden
                      raise "Unknown mode"
                    end
 
-            file.puts "mkdir -p #{dst_path}" % [dst_path]
+            file.puts "mkdir -p #{dst_path}"
             file.puts "mount -n --bind #{src_path} #{dst_path}"
             file.puts "mount -n --bind -o remount,#{mode} #{src_path} #{dst_path}"
           end


### PR DESCRIPTION
I found this while testing the CF vagrant installer on VMware workstation. The shared folder path is `/mnt/hgfs/!%vagrant` which ruby thought was a format string.

Info here if you're curious:

https://github.com/mitchellh/vagrant/issues/1756
