### PR TITLE
Ensure that all stream responses are displayed.

### DIFF
--- a/warden/lib/warden/repl/repl_v2.rb
+++ b/warden/lib/warden/repl/repl_v2.rb
@@ -191,6 +191,7 @@ module Warden::Repl
           # TODO: Need to eliminate special case for run command.
           command = to_stream_command(command) if type == :run
           response = @client.stream(command, &process_stream)
+          process_stream.call(response)
           command_info[:exit_status] = response.exit_status if type == :run
         else
           response = @client.call(command)


### PR DESCRIPTION
I noticed this while using the REPL warden client and testing `run` commands. If the job returns with an exit status on the first call to `read` within the stream response processor, the `process_stream` lambda won't be called.
