### PR TITLE
Change stdout/stderr socket permissions so vcap can connect to them

### DIFF
--- a/warden/src/iomux/util.c
+++ b/warden/src/iomux/util.c
@@ -135,6 +135,10 @@ int create_unix_domain_listener(const char *path, int backlog) {
     return -1;
   }
 
+  if (0 != chmod(path, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) {
+    return -1;
+  }
+
   return fd;
 }
 


### PR DESCRIPTION
Signed-off-by: Glenn Oppegard goppegard@pivotallabs.com

We need this so we don't have to run the dea logging agent as root
