### PR TITLE
Changes to enable working on Windows with dea_ng

### DIFF
--- a/em-warden-client/spec/client_spec.rb
+++ b/em-warden-client/spec/client_spec.rb
@@ -3,156 +3,169 @@ require "support/mock_warden_server"
 
 describe EventMachine::Warden::Client do
   describe "events" do
-    it "should emit the 'connected' event upon connection completion" do
-      server = MockWardenServer.new
-      received_connected = false
+    shared_examples_for "connection events" do
 
-      em do
-        server.start
-        conn = server.create_connection
-        conn.on(:connected) { received_connected = true }
-        EM.stop
+      it "should emit the 'connected' event upon connection completion" do
+        server = MockWardenServer.new(nil, socket_path)
+        received_connected = false
+
+        em do
+          server.start
+          conn = server.create_connection
+          conn.on(:connected) { received_connected = true }
+          EM.stop
+        end
+
+        received_connected.should be_true
       end
 
-      received_connected.should be_true
+      it "should emit the 'disconnected' event upon connection termination" do
+        server = MockWardenServer.new(nil, socket_path)
+
+        received_disconnected = false
+
+        em do
+          server.start
+          conn = server.create_connection
+          conn.on(:disconnected) { received_disconnected = true }
+          EM.stop
+        end
+
+        received_disconnected.should be_true
+      end
     end
 
-    it "should emit the 'disconnected' event upon connection termination" do
-      server = MockWardenServer.new
-      received_disconnected = false
+    context "when it has a file path" do
+      let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+      it_should_behave_like "connection events"
+    end
 
-      em do
-        server.start
-        conn = server.create_connection
-        conn.on(:disconnected) { received_disconnected = true }
-        EM.stop
-      end
-
-      received_disconnected.should be_true
+    context "when it has a network path" do
+      let(:socket_path) { 'tcp://localhost:43248' }
+      it_should_behave_like "connection events"
     end
   end
 
   describe "when connected" do
-    it "should return non-error payloads" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello")
-      expected_response = Warden::Protocol::EchoResponse.new(:message => "world")
+    shared_examples_for "connected" do
 
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_return(expected_response)
-      server = MockWardenServer.new(handler)
-      actual_response = nil
+      it "should return non-error payloads" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello")
+        expected_response = Warden::Protocol::EchoResponse.new(:message => "world")
 
-      em do
-        server.start
-        conn = server.create_connection
-        conn.call(request) do |r|
-          actual_response = r.get
-          EM.stop
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_return(expected_response)
+        server = MockWardenServer.new(handler, socket_path)
+        actual_response = nil
+
+        em do
+          server.start
+          conn = server.create_connection
+          conn.call(request) do |r|
+            actual_response = r.get
+            EM.stop
+          end
+        end
+
+        actual_response.should == expected_response
+      end
+
+      it "should raise error payloads" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello world")
+        expected_response = MockWardenServer::Error.new("test error")
+
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_raise(expected_response)
+        server = MockWardenServer.new(handler, socket_path)
+
+        em do
+          server.start
+          conn = server.create_connection
+          conn.call(request) do |r|
+            expect do
+              r.get
+            end.to raise_error(/test error/)
+            EM.stop
+          end
         end
       end
 
-      actual_response.should == expected_response
+      it "should queue subsequent requests" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello")
+        expected_response = Warden::Protocol::EchoResponse.new(:message => "world")
+
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).twice.and_return(expected_response)
+        server = MockWardenServer.new(handler, socket_path)
+
+        em do
+          server.start
+          conn = server.create_connection
+          conn.call(request)
+          conn.call(request) { |r| EM.stop }
+        end
+      end
+
+      it "should raise on disconnect" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello world")
+
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_return(nil)
+        server = MockWardenServer.new(handler, socket_path)
+
+        em do
+          server.start
+
+          conn = server.create_connection
+          conn.call(request) do |r|
+            expect do
+              r.get
+            end.to raise_error(EventMachine::Warden::Client::ConnectionError, /disconnected/i)
+
+            EM.stop
+          end
+
+          # Close server side of the connection
+          ::EM.add_timer(0.01) do
+            server.connections.first.close_connection
+          end
+        end
+      end
     end
 
-    it "should raise error payloads" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello world")
-      expected_response = MockWardenServer::Error.new("test error")
-
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_raise(expected_response)
-      server = MockWardenServer.new(handler)
-
-      em do
-        server.start
-        conn = server.create_connection
-        conn.call(request) do |r|
-          expect do
-            r.get
-          end.to raise_error(/test error/)
-          EM.stop
-        end
-      end
+    context "when it has a file path" do
+      let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+      it_should_behave_like "connected"
     end
 
-    it "should queue subsequent requests" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello")
-      expected_response = Warden::Protocol::EchoResponse.new(:message => "world")
-
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).twice.and_return(expected_response)
-      server = MockWardenServer.new(handler)
-
-      em do
-        server.start
-        conn = server.create_connection
-        conn.call(request)
-        conn.call(request) { |r| EM.stop }
-      end
-    end
-
-    it "should raise on disconnect" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello world")
-      expected_response = RuntimeError.new
-
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_return(nil)
-      server = MockWardenServer.new(handler)
-
-      em do
-        server.start
-
-        conn = server.create_connection
-        conn.call(request) do |r|
-          expect do
-            r.get
-          end.to raise_error(EventMachine::Warden::Client::ConnectionError, /disconnected/i)
-
-          EM.stop
-        end
-
-        # Close server side of the connection
-        ::EM.add_timer(0.01) do
-          server.connections.first.close_connection
-        end
-      end
+    context "when it has a network path" do
+      let(:socket_path) { 'tcp://localhost:43248' }
+      it_should_behave_like "connected"
     end
 
     describe "idle timer" do
       let(:request) { Warden::Protocol::EchoRequest.new(:message => "hello") }
       let(:response) { Warden::Protocol::EchoResponse.new(:message => "world") }
 
-      let(:server) do
-        handler = double
-        handler.stub(request.class.type_underscored).and_return(response)
+      shared_examples_for "idle timer events" do
+        let(:server) do
+          handler = double
+          handler.stub(request.class.type_underscored).and_return(response)
 
-        MockWardenServer.new(handler)
-      end
-
-      let(:conn) do
-        server.create_connection
-      end
-
-      it "should setup an idle timer after connecting" do
-        em do
-          server.start
-
-          conn.idle_timeout = 0.05
-
-          # Check state after 2 * idle_timeout
-          EM.add_timer(0.10) do
-            conn.should_not be_connected
-            EM.stop
-          end
+          server = MockWardenServer.new(handler, socket_path)
+          server
         end
-      end
 
-      it "should setup an idle timer after executing a request" do
-        em do
-          server.start
+        let(:conn) do
+          server.create_connection
+        end
 
-          conn.idle_timeout = 0.05
+        it "should setup an idle timer after connecting" do
+          em do
+            server.start
 
-          conn.call(request) do |_|
+            conn.idle_timeout = 0.05
+
             # Check state after 2 * idle_timeout
             EM.add_timer(0.10) do
               conn.should_not be_connected
@@ -160,24 +173,50 @@ describe EventMachine::Warden::Client do
             end
           end
         end
-      end
 
-      it "should cancel the idle timer when busy" do
-        em do
-          server.start
+        it "should setup an idle timer after executing a request" do
+          em do
+            server.start
 
-          conn.idle_timeout = 0.05
+            conn.idle_timeout = 0.05
 
-          EM.add_periodic_timer(0.01) do
-            conn.call(request)
-          end
-
-          # Check state after 2 * idle_timeout
-          EM.add_timer(0.10) do
-            conn.should be_connected
-            EM.stop
+            conn.call(request) do |_|
+              # Check state after 2 * idle_timeout
+              EM.add_timer(0.10) do
+                conn.should_not be_connected
+                EM.stop
+              end
+            end
           end
         end
+
+        it "should cancel the idle timer when busy" do
+          em do
+            server.start
+
+            conn.idle_timeout = 0.05
+
+            EM.add_periodic_timer(0.01) do
+              conn.call(request)
+            end
+
+            # Check state after 2 * idle_timeout
+            EM.add_timer(0.10) do
+              conn.should be_connected
+              EM.stop
+            end
+          end
+        end
+      end
+
+      context "when it has a file path" do
+        let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+        it_should_behave_like "idle timer events"
+      end
+
+      context "when it has a network path" do
+        let(:socket_path) { 'tcp://localhost:43248' }
+        it_should_behave_like "idle timer events"
       end
     end
   end

--- a/em-warden-client/spec/fiber_aware_client_spec.rb
+++ b/em-warden-client/spec/fiber_aware_client_spec.rb
@@ -3,126 +3,174 @@ require "support/mock_warden_server"
 
 describe EventMachine::Warden::FiberAwareClient do
   describe "#connected" do
-    it "should yield the calling fiber until connected" do
-      server = MockWardenServer.new
+    shared_examples_for "yield the calling fiber for connected" do
+      it "should yield the calling fiber until connected" do
+        server = MockWardenServer.new(nil, socket_path)
 
-      em do
-        server.start
-        client = server.create_fiber_aware_client
-        Fiber.new do
-          client.connect
-          client.connected?.should be_true
-          EM.stop
-        end.resume
+        em do
+          server.start
+          client = server.create_fiber_aware_client
+          Fiber.new do
+            client.connect
+            client.connected?.should be_true
+            EM.stop
+          end.resume
+        end
       end
+    end
+
+    context "when it has a file path" do
+      let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+      it_should_behave_like "yield the calling fiber for connected"
+    end
+
+    context "when it has a network path" do
+      let(:socket_path) { 'tcp://localhost:43248' }
+      it_should_behave_like "yield the calling fiber for connected"
     end
   end
 
   describe "#disconnect" do
-    it "should yield the calling fiber until disconnected" do
-      server = MockWardenServer.new
+    shared_examples_for "yield the calling fiber for disconnect" do
+      it "should yield the calling fiber until disconnected" do
+        server = MockWardenServer.new(nil, socket_path)
 
-      em do
-        server.start
-        client = server.create_fiber_aware_client
-        Fiber.new do
-          client.connect
-          client.connected?.should be_true
-          client.disconnect
-          client.connected?.should be_false
-          EM.stop
-        end.resume
+        em do
+          server.start
+          client = server.create_fiber_aware_client
+          Fiber.new do
+            client.connect
+            client.connected?.should be_true
+            client.disconnect
+            client.connected?.should be_false
+            EM.stop
+          end.resume
+        end
       end
+    end
+
+    context "when it has a file path" do
+      let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+      it_should_behave_like "yield the calling fiber for disconnect"
+    end
+
+    context "when it has a network path" do
+      let(:socket_path) { 'tcp://localhost:43248' }
+      it_should_behave_like "yield the calling fiber for disconnect"
     end
   end
 
   describe "#method_missing" do
-    it "should return non-error payloads" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello")
-      expected_response = Warden::Protocol::EchoResponse.new(:message => "world")
+    shared_examples_for "method missing payloads" do
+      it "should return non-error payloads" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello")
+        expected_response = Warden::Protocol::EchoResponse.new(:message => "world")
 
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_return(expected_response)
-      server = MockWardenServer.new(handler)
-      actual_response = nil
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_return(expected_response)
+        server = MockWardenServer.new(handler, socket_path)
+        actual_response = nil
 
-      em do
-        server.start
-        client = server.create_fiber_aware_client
-        Fiber.new do
-          client.connect
-          actual_response = client.call(request)
-          EM.stop
-        end.resume
+        em do
+          server.start
+          client = server.create_fiber_aware_client
+          Fiber.new do
+            client.connect
+            actual_response = client.call(request)
+            EM.stop
+          end.resume
+        end
+
+        actual_response.should == expected_response
       end
 
-      actual_response.should == expected_response
+      it "should raise error payloads" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello world")
+        expected_response = MockWardenServer::Error.new("test error")
+
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_raise(expected_response)
+        server = MockWardenServer.new(handler, socket_path)
+
+        em do
+          server.start
+          client = server.create_fiber_aware_client
+          Fiber.new do
+            client.connect
+            expect do
+              client.call(request)
+            end.to raise_error(/test error/)
+            EM.stop
+          end.resume
+        end
+      end
     end
 
-    it "should raise error payloads" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello world")
-      expected_response = MockWardenServer::Error.new("test error")
+    context "when it has a file path" do
+      let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+      it_should_behave_like "method missing payloads"
+    end
 
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_raise(expected_response)
-      server = MockWardenServer.new(handler)
-
-      em do
-        server.start
-        client = server.create_fiber_aware_client
-        Fiber.new do
-          client.connect
-          expect do
-            client.call(request)
-          end.to raise_error(/test error/)
-          EM.stop
-        end.resume
-      end
+    context "when it has a network path" do
+      let(:socket_path) { 'tcp://localhost:43248' }
+      it_should_behave_like "method missing payloads"
     end
   end
 
   describe "#method_missing with old API" do
-    it "should return non-error payloads" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello")
-      response = Warden::Protocol::EchoResponse.new(:message => "world")
+    shared_examples_for "method missing old API payloads" do
+      it "should return non-error payloads" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello")
+        response = Warden::Protocol::EchoResponse.new(:message => "world")
 
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_return(response)
-      server = MockWardenServer.new(handler)
-      actual_response = nil
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_return(response)
+        server = MockWardenServer.new(handler, socket_path)
+        actual_response = nil
 
-      em do
-        server.start
-        client = server.create_fiber_aware_client
-        Fiber.new do
-          client.connect
-          actual_response = client.echo("hello")
-          EM.stop
-        end.resume
+        em do
+          server.start
+          client = server.create_fiber_aware_client
+          Fiber.new do
+            client.connect
+            actual_response = client.echo("hello")
+            EM.stop
+          end.resume
+        end
+
+        actual_response.should == "world"
       end
 
-      actual_response.should == "world"
+      it "should raise error payloads" do
+        request = Warden::Protocol::EchoRequest.new(:message => "hello")
+        response = MockWardenServer::Error.new("test error")
+
+        handler = mock()
+        handler.should_receive(request.class.type_underscored).and_raise(response)
+        server = MockWardenServer.new(handler, socket_path)
+
+        em do
+          server.start
+          client = server.create_fiber_aware_client
+          Fiber.new do
+            client.connect
+            expect do
+              client.echo("hello")
+            end.to raise_error(/test error/)
+            EM.stop
+          end.resume
+        end
+      end
     end
 
-    it "should raise error payloads" do
-      request = Warden::Protocol::EchoRequest.new(:message => "hello")
-      response = MockWardenServer::Error.new("test error")
+    context "when it has a file path" do
+      let(:socket_path) { File.join(Dir.mktmpdir, "warden.sock") }
+      it_should_behave_like "method missing old API payloads"
+    end
 
-      handler = mock()
-      handler.should_receive(request.class.type_underscored).and_raise(response)
-      server = MockWardenServer.new(handler)
-
-      em do
-        server.start
-        client = server.create_fiber_aware_client
-        Fiber.new do
-          client.connect
-          expect do
-            client.echo("hello")
-          end.to raise_error(/test error/)
-          EM.stop
-        end.resume
-      end
+    context "when it has a network path" do
+      let(:socket_path) { 'tcp://localhost:43248' }
+      it_should_behave_like "method missing old API payloads"
     end
   end
 end

--- a/warden-client/lib/warden/client.rb
+++ b/warden-client/lib/warden/client.rb
@@ -11,8 +11,9 @@ module Warden
 
     attr_reader :path
 
-    def initialize(path)
+    def initialize(path, port = nil)
       @path = path
+      @port = port
       @v1mode = false
     end
 
@@ -22,7 +23,11 @@ module Warden
 
     def connect
       raise "already connected" if connected?
-      @sock = ::UNIXSocket.new(path)
+      if @port.nil?
+        @sock = ::UNIXSocket.new(path)
+      else
+        @sock = ::TCPSocket.new(@path, @port)
+      end
     end
 
     def disconnect


### PR DESCRIPTION
Change em-warden, warden client and warden proto so that it will work with a local connection with port on windows and not try to connnect to a unix domain.
