### PR TITLE
Add Trusty to supported releases of `setup_fs_ubuntu()`

### DIFF
--- a/warden/root/linux/skeleton/lib/common.sh
+++ b/warden/root/linux/skeleton/lib/common.sh
@@ -60,7 +60,7 @@ function setup_fs_ubuntu() {
   lucid|natty|oneiric)
     mount -n -t aufs -o br:tmp/rootfs=rw:$rootfs_path=ro+wh none mnt
     ;;
-  precise)
+  precise|trusty)
     mount -n -t overlayfs -o rw,upperdir=tmp/rootfs,lowerdir=$rootfs_path none mnt
     ;;
   *)


### PR DESCRIPTION
Hi,

To work on supporting Ubuntu 14.04, I added Trusty to the supported release names of  the `setup_fs_ubuntu()`.
I've confirmed that this commit works on a daily build of Trusty.
