### PR TITLE
Dispatch results are logged at debug level instead of info.

### DIFF
--- a/warden/lib/warden/container/base.rb
+++ b/warden/lib/warden/container/base.rb
@@ -297,7 +297,7 @@ module Warden
 
         t2 = Time.now
 
-        logger.info("%s (took %.6f)" % [klass_name, t2 - t1],
+        logger.debug("%s (took %.6f)" % [klass_name, t2 - t1],
                     :request => request.to_hash,
                     :response => response.to_hash)
 


### PR DESCRIPTION
This logging output includes the container's environment variables which may include sensitive information like service credentials. It should be logged at the debug level so that we easily turn this logging off in production.
