### PR TITLE
add support for connecting repl to tcp

### DIFF
--- a/warden/lib/warden/repl/repl_v2.rb
+++ b/warden/lib/warden/repl/repl_v2.rb
@@ -32,8 +32,9 @@ module Warden::Repl
       @exit_on_error = opts[:exit_on_error]
       @exit_on_error = false unless @exit_on_error
       @trace = opts[:trace] == true
-      @socket_path = opts[:socket_path] || "/tmp/warden.sock"
-      @client = Warden::Client.new(@socket_path)
+      address = opts[:socket_path] || opts[:address] || "/tmp/warden.sock"
+      port = opts[:port]
+      @client = Warden::Client.new(address, port)
       @history_path = opts[:history_path] || File.join(ENV['HOME'],
                                                        '.warden-history')
       @commands = command_descriptions.keys # for Readline's keyword completion

--- a/warden/lib/warden/repl/repl_v2_runner.rb
+++ b/warden/lib/warden/repl/repl_v2_runner.rb
@@ -26,6 +26,14 @@ EOT
           options[:socket_path] = socket_path
         end
 
+        op.on("--address address", "Warden server address.") do |address|
+          options[:address] = address
+        end
+
+        op.on("--port port", "Warden server port.") do |port|
+          options[:port] = port.to_i
+        end
+
         op.on("--trace", "Writes each command preceded by a '+' to stdout before" \
               + " executing.") do |trace|
           options[:trace] = true

--- a/warden/spec/repl/repl_v2_runner_spec.rb
+++ b/warden/spec/repl/repl_v2_runner_spec.rb
@@ -12,6 +12,8 @@ describe Warden::Repl::ReplRunner do
         expected_options = {
           :trace => true,
           :socket_path => "/foo/bar",
+          :address => "127.0.0.1",
+          :port => 1234,
           :exit_on_error => true,
         }
         Warden::Repl::Repl.should_receive(:new).once.with(expected_options).
@@ -19,6 +21,8 @@ describe Warden::Repl::ReplRunner do
 
         expect do
           described_class.run(["--trace", "--exit_on_error",
+                               "--address", "127.0.0.1",
+                               "--port", "1234",
                                "--socket", "/foo/bar"])
         end.to raise_error(SystemExit) do |error|
           error.status.should == 0


### PR DESCRIPTION
This allows the REPL to connect to Warden via TCP instead of a socket. The Ruby library already supports this.
