### PR TITLE
Sync fs and move image deletion after loop detach

### DIFF
--- a/warden/spec/container/linux_spec.rb
+++ b/warden/spec/container/linux_spec.rb
@@ -59,9 +59,10 @@ describe "linux", :platform => "linux", :needs_root => true do
     unmount_depot
 
     execute("rmdir #{container_depot_path}")
-    execute("rm #{container_depot_file}")
+    execute("sync")
 
     execute("losetup --all | grep #{container_depot_file} | cut --delimiter=: --fields=1 | xargs --no-run-if-empty --max-args=1 losetup --detach")
+    execute("rm #{container_depot_file}")
   end
 
   def execute(command)


### PR DESCRIPTION
The warden tests frequently fail under VMware due to an error detaching a loop device that was associated with a mounted disk image:

```
  loop: can't delete device /dev/loop0: Device or resource busy
```

In order to reduce the likelihood of the problem, a `sync` was added before the detach and the deletion of the image file was moved until after the detach.  After repeated runs with these modifications, I have not seen the failures occur.
