### PR TITLE
Don't rsync .vagrant into the VM

### DIFF
--- a/bin/rsync_workspace_into_vm.sh
+++ b/bin/rsync_workspace_into_vm.sh
@@ -2,4 +2,4 @@
 set -e -x -u
 
 vagrant ssh-config > ssh_config
-rsync -arq --rsh="ssh -F ssh_config" $1/ default:workspace
+rsync -arq --rsh="ssh -F ssh_config" --exclude .vagrant $1/ default:workspace


### PR DESCRIPTION
The rsync script does not exclude .vagrant when populating the test VM with the code so if you happened to `vagrant up` the warden test VM from the warden directory, you get your virtual machine copied into your
other virtual machine.

This simply excludes .vagrant from the sync.
