### PR TITLE
Use MASQUERADE instead of SNAT for container NAT

### DIFF
--- a/warden/root/linux/net.sh
+++ b/warden/root/linux/net.sh
@@ -188,11 +188,11 @@ function setup_nat() {
       --jump ${nat_postrouting_chain}
 
   # Enable NAT for traffic coming from containers
-  (iptables -t nat -S ${nat_postrouting_chain} | grep -q "\-j SNAT\b") ||
+  (iptables -t nat -S ${nat_postrouting_chain} | grep -q "\-j MASQUERADE\b") ||
     iptables -t nat -A ${nat_postrouting_chain} \
       --source ${POOL_NETWORK} \
-      --jump SNAT \
-      --to $(external_ip)
+      ! --destination ${POOL_NETWORK} \
+      --jump MASQUERADE
 }
 
 case "${1}" in


### PR DESCRIPTION
When warden is running on hosts with multiple networks, the address associated with the default route should not always be used as the source of the traffic. By using MASQUERADE, the packets will pick up the address associated with adapter used to flow the request.