### PR TITLE
Use the correct stop command in do_destroy

### DIFF
--- a/warden/lib/warden/container/insecure.rb
+++ b/warden/lib/warden/container/insecure.rb
@@ -33,7 +33,7 @@ module Warden
       end
 
       def do_destroy(request, response)
-        sh File.join(root_path, "stop.sh"), container_path, "-w", "0", raise: false
+        sh File.join(container_path, "stop.sh"), "-w", "0", raise: false
         sh File.join(root_path, "destroy.sh"), container_path
         logger.debug("Container destroyed")
       end

--- a/warden/lib/warden/container/linux.rb
+++ b/warden/lib/warden/container/linux.rb
@@ -120,7 +120,7 @@ module Warden
       end
 
       def do_destroy(request, response)
-        sh File.join(root_path, "stop.sh"), container_path, "-w", "0", raise: false
+        sh File.join(container_path, "stop.sh"), "-w", "0", raise: false
         sh File.join(root_path, "destroy.sh"), container_path
         logger.debug("Container destroyed")
 


### PR DESCRIPTION
Commit a20c4e8a596c08d0d55dfcb7370152db2e64451d added code that was supposed to drive the container stop script during destruction but it specified the wrong path and added an extra argument. This resulted in several errors in the warden logs:

```
{
  "timestamp": 1432009424.936991,
  "message": "Exited with status 255 (0.003s): [[\"/var/vcap/data/packages/warden/warden/src/closefds/closefds\", \"/var/vcap/data/packages/warden/warden/src/closefds/closefds\"], \"/var/vcap/data/packages/warden/warden/root/linux/stop.sh\", \"/var/vcap/data/warden/depot/18ltntkeneu\", \"-w\", \"0\"]",
  "log_level": "warn",
  "source": "Warden::Container::Linux",
  "data": {
    "handle": "18ltntkeneu",
    "stdout": "",
    "stderr": "execvp: No such file or directory\n"
  },
  "thread_id": 70055141495560,
  "fiber_id": 70055154427100,
  "process_id": 6965,
  "file": "/var/vcap/data/packages/warden/3ec87c9a5041e4550900efe93155d78bd01db9a4.1-48ee7a8aec777b29e4cf941d80940acc35fa2bb8/warden/lib/warden/container/spawn.rb",
  "lineno": 135,
  "method": "set_deferred_success"
}
```

This commit updates the command to use the correct path and remove the extraneous argument.