### PR TITLE
Fix flakey network related tests

### DIFF
--- a/warden/spec/container/linux_spec.rb
+++ b/warden/spec/container/linux_spec.rb
@@ -511,7 +511,7 @@ describe "linux", :platform => "linux", :needs_root => true do
                    :script => server_script).job_id
 
       # Try to connect to the server container
-      client_script = "nc -w1 #{server_container[:ip]} #{port}"
+      client_script = "sleep 1; nc -w1 #{server_container[:ip]} #{port}"
       response = run(client_container[:handle], client_script)
 
       unless response.exit_status.zero?
@@ -530,13 +530,14 @@ describe "linux", :platform => "linux", :needs_root => true do
                             :script => server_script).job_id
 
       # Try to connect to the server container
-      client_script = "echo ok > /dev/udp/#{server_container[:ip]}/#{port}"
+      client_script = "sleep 1; echo ok > /dev/udp/#{server_container[:ip]}/#{port}"
       run(client_container[:handle], client_script)
 
-      cleanup_script = "echo fail > /dev/udp/#{server_container[:ip]}/#{port}"
+      cleanup_script = "sleep 1; echo fail > /dev/udp/#{server_container[:ip]}/#{port}"
       client.run(:handle => server_container[:handle], :script => cleanup_script)
 
       response = client.link(:handle => server_container[:handle], :job_id => job_id)
+
       response.stdout.strip == "ok"
     end
 

--- a/warden/spec/support/examples/lifecycle.rb
+++ b/warden/spec/support/examples/lifecycle.rb
@@ -118,7 +118,7 @@ module Warden::Protocol
       attr_reader :handle
 
       before do
-        @handle = client.create(:grace_time => 1).handle
+        @handle = client.create(:grace_time => 3).handle
       end
 
       it "should destroy unreferenced container" do
@@ -126,7 +126,7 @@ module Warden::Protocol
         client.disconnect
 
         # Let the grace time pass
-        sleep 1.1
+        sleep 3.1
 
         # Test that the container can no longer be referenced
         expect do
@@ -142,7 +142,7 @@ module Warden::Protocol
         client.disconnect
 
         # Let the grace time pass
-        sleep 1.1
+        sleep 3.1
 
         # Test that the container can no longer be referenced
         expect do
@@ -157,7 +157,7 @@ module Warden::Protocol
         client.reconnect
 
         # Wait some time, but don't run out of grace time
-        sleep 0.1
+        sleep 2
 
         # Test that the container can still be referenced
         expect do
@@ -166,7 +166,7 @@ module Warden::Protocol
         end.to_not raise_error
 
         # Wait for the original grace time to run out
-        sleep 1.0
+        sleep 3.0
 
         # The new connection should have taken over ownership of this
         # container and canceled the original grace time


### PR DESCRIPTION
[#95169062]

Warden is sometimes flakey about returning stdout straight after you run a process. This fixes the tests flakes where output isn't being immediately captured.

Signed-off-by: Afolabi Badmos <abadmos@pivotal.io>