### PR TITLE
Disk quotas should not break if the rootfs contains the vcap user

### DIFF
--- a/warden/spec/container/linux_spec.rb
+++ b/warden/spec/container/linux_spec.rb
@@ -404,7 +404,7 @@ describe "linux", :platform => "linux", :needs_root => true do
         response.exit_status.should == 0
       end
 
-      it 'should still own his files' do
+      it "should still own vcap's files" do
         response = run("stat -c %u /home/vcap/a_file.txt", vcap_handle)
         response.exit_status.should == 0
         response.stdout.strip!.should == "10001"

--- a/warden/spec/container/linux_spec.rb
+++ b/warden/spec/container/linux_spec.rb
@@ -391,14 +391,17 @@ describe "linux", :platform => "linux", :needs_root => true do
       end
 
       it 'should apply different disk quota on every container' do
-        limit_response = limit_disk(:byte_limit => 2 * 1024 * 1024)
+        limit_response = limit_disk(:byte_limit => 4 * 1024 * 1024)
         vcap_limit_response = limit_disk(:handle => vcap_handle, :byte_limit => 4 * 1024 * 1024)
 
         limit_response = limit_disk()
-        limit_response.byte_limit.should == 2 * 1024 * 1024
+        limit_response.byte_limit.should == 4 * 1024 * 1024
 
         vcap_limit_response = limit_disk(:handle => vcap_handle)
         vcap_limit_response.byte_limit.should == 4 * 1024 * 1024
+
+        response = run("dd if=/dev/zero of=/tmp/test bs=1M count=3")
+        response.exit_status.should == 0
 
         response = run("dd if=/dev/zero of=/tmp/test bs=1M count=3", vcap_handle)
         response.exit_status.should == 0
@@ -420,6 +423,14 @@ describe "linux", :platform => "linux", :needs_root => true do
         response = run("stat -c %g /tmp/a_file.txt", vcap_handle)
         response.exit_status.should == 0
         response.stdout.strip!.should == "10001"
+
+        response = run("cat /etc/passwd | grep vcap: | cut -d ':' -f 3", vcap_handle)
+        response.exit_status.should == 0
+        response.stdout.strip.should == "10001"
+
+        response = run("cat /etc/group | grep vcap: | cut -d ':' -f 3", vcap_handle)
+        response.exit_status.should == 0
+        response.stdout.strip.should == "10001"
       end
     end
 


### PR DESCRIPTION
[#95694242]

Since we're removing the creation of vcap from Garden, the vcap user needs to be added to the CF rootfs. Since the same rootfs will be used with both Garden and Warden, Warden needs to be able to handle vcap already existing. Currently it won't try to recreate vcap if it already exists, but the problem is that then all vcap users across containers will share the same UID, which will break disk quotas. Change the UIDs to make sure disk quotas still work.

Signed-off-by: Afolabi Badmos <abadmos@pivotal.io>