### PR TITLE
Kepp track of containers when destroy fails

### DIFF
--- a/warden/lib/warden/container/base.rb
+++ b/warden/lib/warden/container/base.rb
@@ -509,10 +509,6 @@ module Warden
           # so there's no info to get anyway.
         end
 
-        delete_snapshot
-
-        self.class.registry.delete(handle)
-
         unless self.state == State::Stopped
           # Ignore, stopping before destroy is a best effort
           begin
@@ -520,12 +516,13 @@ module Warden
           rescue WardenError => e
           end
         end
-
-        self.state = State::Destroyed
       end
 
       def after_destroy
+        delete_snapshot
         release
+        self.state = State::Destroyed
+        self.class.registry.delete(handle)
       end
 
       def do_destroy(request, response)
@@ -733,10 +730,6 @@ module Warden
 
       def container_info
         obituary || dispatch(Warden::Protocol::InfoRequest.new(:handle => handle))
-      end
-
-      def state
-        @state
       end
 
       def state=(state)

--- a/warden/spec/container/base_spec.rb
+++ b/warden/spec/container/base_spec.rb
@@ -273,6 +273,36 @@ describe Warden::Container::Base do
         end.to_not raise_error
       end
     end
+
+    context "when do_destroy fails" do
+      before do
+        @container.should_receive(:do_destroy).and_raise(Warden::WardenError.new("failure"))
+      end
+
+      it "should not be destroyed" do
+        expect do
+          @container.dispatch(Warden::Protocol::DestroyRequest.new)
+        end.to raise_error
+
+        expect(@container.state).to_not eql(Warden::Container::State::Destroyed)
+      end
+
+      it "should not be removed from the registry" do
+        expect do
+          @container.dispatch(Warden::Protocol::DestroyRequest.new)
+        end.to raise_error
+
+        expect(Container.registry.size).to eq 1
+      end
+
+      it "should not delete the snapshot" do
+        @container.should_receive(:delete_snapshot).once
+
+        expect do
+          @container.dispatch(Warden::Protocol::DestroyRequest.new)
+        end.to raise_error
+      end
+    end
   end
 
   describe "connection management" do


### PR DESCRIPTION
Do not do anything destructive when destroy fails

The common case is when destroy fails, e.g., iptables or directory removal
failures, raise an exception. All of the OS resources, network interfaces,
uid, and wshd are abandoned. Eventually you have a DEA with capacity but
nothing can actually start.