### PR TITLE
Use 1.2.3.4 as destination for detecting local IP

### DIFF
--- a/warden/root/linux/net.sh
+++ b/warden/root/linux/net.sh
@@ -21,7 +21,7 @@ ALLOW_HOST_ACCESS=${ALLOW_HOST_ACCESS:-false}
 
 function external_ip() {
   # The ';tx;d;:x' trick deletes non-matching lines
-  ip route get 8.8.8.8 | sed 's/.*src\s\(.*\)\s/\1/;tx;d;:x'
+  ip route get 1.2.3.4 | sed 's/.*src\s\(.*\)\s/\1/;tx;d;:x'
 }
 
 function teardown_deprecated_rules() {

--- a/warden/root/linux/skeleton/net.sh
+++ b/warden/root/linux/skeleton/net.sh
@@ -18,7 +18,7 @@ nat_prerouting_chain="warden-prerouting"
 nat_instance_prefix="warden-i-"
 nat_instance_chain="${filter_instance_prefix}${id}"
 
-external_ip=$(ip route get 8.8.8.8 | sed 's/.*src\s\(.*\)\s/\1/;tx;d;:x')
+external_ip=$(ip route get 1.2.3.4 | sed 's/.*src\s\(.*\)\s/\1/;tx;d;:x')
 
 function teardown_filter() {
   echo "Teardown filter"


### PR DESCRIPTION
Use the same non-routable IP address used [here](https://github.com/pivotal-golang/localip/blob/master/localip.go#L7) when detecting the local IP.

There are currently 3 IPs being used for local IP detection:
- `1.2.3.4`: https://github.com/pivotal-golang/localip/blob/master/localip.go#L7
- `198.41.0.4`: https://github.com/cloudfoundry/vcap-common/pull/19/files#diff-ef31f1c999b5cb68d4fecf57aba1e514L11
- `8.8.8.8` here, in warden