### PR TITLE
Allow destroy to work regardless of links

### DIFF
--- a/warden/root/linux/skeleton/destroy.sh
+++ b/warden/root/linux/skeleton/destroy.sh
@@ -11,7 +11,7 @@ source ./etc/config
 
 ./net.sh teardown
 
-ip link del ${network_ifb_iface}
+ip link del ${network_ifb_iface} || true
 
 if [ -f ./run/wshd.pid ]
 then


### PR DESCRIPTION
- During a deploy, links may not be present

Signed-off-by: Matthew Sykes <matthew.sykes@gmail.com>