### PR TITLE
Feature/add container timeout

### DIFF
--- a/warden/config/linux.yml
+++ b/warden/config/linux.yml
@@ -15,6 +15,8 @@ server:
   #
   container_grace_time: 300
 
+  container_stop_timeout: 80
+
   unix_domain_permissions: 0777
 
   # Specifies the path to the base chroot used as the read-only root

--- a/warden/lib/warden/config.rb
+++ b/warden/lib/warden/config.rb
@@ -9,7 +9,8 @@ module Warden
         "unix_domain_path"        => "/tmp/warden.sock",
         "unix_domain_permissions" => 0755,
         "container_klass"         => "Warden::Container::Insecure",
-        "container_grace_time"    => (5 * 60), # 5 minutes
+        "container_grace_time"    => (5 * 60), # 5 minutes,
+        "container_stop_timeout"  => 80,
         "job_output_limit"        => (10 * 1024 * 1024), # 10 megabytes
         "quota" => {
           "disk_quota_enabled" => true,
@@ -35,6 +36,7 @@ module Warden
 
           "container_klass"       => String,
           "container_grace_time"  => enum(nil, Integer),
+          "container_stop_timeout"  => Integer,
 
           # See getrlimit(2) for details. Integer values are passed verbatim.
           optional("container_rlimits") => {

--- a/warden/lib/warden/container/base.rb
+++ b/warden/lib/warden/container/base.rb
@@ -28,6 +28,7 @@ module Warden
         attr_reader :container_rootfs_path
         attr_reader :container_depot_path
         attr_reader :container_iface_mtu
+        attr_reader :container_stop_timeout
 
         # Stores a map of handles to their respective container objects. Only
         # live containers are reachable through this map. Containers are only
@@ -53,6 +54,7 @@ module Warden
 
           # Default MTU 1500
           @container_iface_mtu = config.network["mtu"]
+          @container_stop_timeout = config.server["container_stop_timeout"]
 
           @container_rootfs_path   = config.server["container_rootfs_path"]
           @container_rootfs_path ||= File.join(@root_path, "base", "rootfs")
@@ -167,6 +169,10 @@ module Warden
 
       def container_iface_mtu
         self.class.container_iface_mtu
+      end
+
+      def container_stop_timeout
+        self.class.container_stop_timeout
       end
 
       def cancel_grace_timer

--- a/warden/lib/warden/container/linux.rb
+++ b/warden/lib/warden/container/linux.rb
@@ -83,6 +83,7 @@ module Warden
           "rootfs_path" => container_rootfs_path,
           "allow_nested_warden" => Server.config.allow_nested_warden?.to_s,
           "container_iface_mtu" => container_iface_mtu,
+          "container_stop_timeout" => container_stop_timeout,
         }
       end
 
@@ -110,8 +111,9 @@ module Warden
       end
 
       def do_stop(request, response)
+        timeout = request.kill ? "0" : "#{env['container_stop_timeout']}"
         args  = [File.join(container_path, "stop.sh")]
-        args += ["-w", "0"] if request.kill
+        args += ["-w", timeout]
 
         sh *args
 

--- a/warden/spec/assets/config/child-linux.yml
+++ b/warden/spec/assets/config/child-linux.yml
@@ -15,6 +15,8 @@ server:
   #
   container_grace_time: 30
 
+  container_stop_timeout: 80
+
   unix_domain_permissions: 0777
 
   # Specifies the path to the base chroot used as the read-only root

--- a/warden/spec/container/linux_nested_spec.rb
+++ b/warden/spec/container/linux_nested_spec.rb
@@ -43,6 +43,7 @@ describe "linux", :platform => "linux", :needs_root => true do
             "container_rootfs_path" => container_rootfs_path,
             "container_depot_path" => container_depot_path,
             "container_grace_time" => nil,
+            "container_stop_timeout" => 80,
             "job_output_limit" => 100 * 1024,
             "allow_nested_warden" => true  },
         "network" => {

--- a/warden/spec/container/linux_spec.rb
+++ b/warden/spec/container/linux_spec.rb
@@ -20,6 +20,7 @@ describe "linux", :platform => "linux", :needs_root => true do
   let(:container_klass) { "Warden::Container::Linux" }
   let(:container_depot_path) { File.join(work_path, "containers") }
   let(:container_depot_file) { container_depot_path + ".img" }
+  let(:container_stop_timeout) { 80 }
   let(:have_uid_support) { true }
   let(:netmask) { Warden::Network::Netmask.new(255, 255, 255, 252) }
   let(:allow_networks) { [] }
@@ -115,6 +116,7 @@ describe "linux", :platform => "linux", :needs_root => true do
               "container_rootfs_path" => container_rootfs_path,
               "container_depot_path" => container_depot_path,
               "container_grace_time" => 5,
+              "container_stop_timeout" => container_stop_timeout,
               "job_output_limit" => job_output_limit,
               "pidfile" => server_pidfile,
               "syslog_socket" => syslog_socket },

--- a/warden/spec/health_check_spec.rb
+++ b/warden/spec/health_check_spec.rb
@@ -47,7 +47,8 @@ describe "health check" do
           "unix_domain_path" => unix_domain_path,
           "container_rootfs_path" => container_rootfs_path,
           "container_depot_path" => container_depot_path,
-          "container_grace_time" => 5
+          "container_grace_time" => 5,
+          "container_stop_timeout" => 80
         },
         "health_server" => {
           "port" => 2345


### PR DESCRIPTION
There are some cases when app is not able to gracefully stop in 10 seconds, which is hardcoded in stop.sh and SIGKILL is not the best solution for this.
This pull request exposing the wait params to warden config.
