### PR TITLE
bugfix: warden cgroups not re-mounting after rebooting

### DIFF
--- a/warden/root/linux/setup.sh
+++ b/warden/root/linux/setup.sh
@@ -18,29 +18,25 @@ then
   rmdir /dev/cgroup
 fi
 
-cgroup_path=/tmp/warden/cgroup
+cgroup_path="/tmp/warden/cgroup"
+mkdir -p "${cgroup_path}"
 
-if [ ! -d $cgroup_path ]
+# Mount tmpfs
+if ! grep "${cgroup_path} " /proc/mounts | cut -d' ' -f3 | grep -q tmpfs
 then
-  mkdir -p $cgroup_path
-
-  # Mount tmpfs
-  if ! grep "${cgroup_path} " /proc/mounts | cut -d' ' -f3 | grep -q tmpfs
-  then
-    mount -t tmpfs none $cgroup_path
-  fi
-
-  # Mount cgroup subsystems individually
-  for subsystem in cpu cpuacct devices memory
-  do
-    mkdir -p $cgroup_path/$subsystem
-
-    if ! grep -q "${cgroup_path}/$subsystem " /proc/mounts
-    then
-      mount -t cgroup -o $subsystem none $cgroup_path/$subsystem
-    fi
-  done
+  mount -t tmpfs none "${cgroup_path}"
 fi
+
+# Mount cgroup subsystems individually
+for subsystem in cpu cpuacct devices memory
+do
+  mkdir -p "${cgroup_path}/${subsystem}"
+
+  if ! grep -q "${cgroup_path}/${subsystem} " /proc/mounts
+  then
+    mount -t cgroup -o "${subsystem}" none "${cgroup_path}/${subsystem}"
+  fi
+done
 
 ./net.sh setup
 


### PR DESCRIPTION
After stopping the VM from IaaS console and then starting afterwards, the cgroup_path `/tmp/warden/cgroup` existed and so the `if` test was skipping the code that should have been re-initializing the warden cgroup fs. 

Since there are already tests in place at each step by removing the outer if we ensure that the warden cgroup fs is re-initialzed when the VM comes back online.

With this change my runner vms come back online useable again after reboot.

(Also added a some best-practices bash quoting for the code block in question.)