### PR TITLE
remove flock in net.sh linux skeleton

### DIFF
--- a/warden/root/linux/skeleton/net.sh
+++ b/warden/root/linux/skeleton/net.sh
@@ -80,11 +80,6 @@ function setup_nat() {
     --jump ${nat_instance_chain}
 }
 
-# Lock execution
-mkdir -p ../tmp
-exec 3> ../tmp/$(basename $0).lock
-flock -x -w 10 3
-
 case "${1}" in
   "setup")
     setup_filter


### PR DESCRIPTION
- it is no longer needed since we have the '-w' flag for iptables
- the extra locking with timeouts can cause containers to fail to start
  concurrently as they all contend for the same lock
- this helps large numbers of containers to be created concurrently
  especially on 4.4 kernels
